### PR TITLE
Centralized sound play

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -46,9 +46,6 @@ export default class BaseButton extends Vue {
     if (!this.item) {
       return;
     }
-    if (this.$status.playCount > 0 && !this.$status.multiPlay) {
-      return;
-    }
     let audioFilename;
     if (typeof this.item.file === "string") {
       audioFilename = this.item.file;
@@ -58,18 +55,17 @@ export default class BaseButton extends Vue {
       ];
     }
     this.pendingNetwork = true;
-    const audio = new Audio(`assets/${audioFilename}`);
+    const audio = this.$status.player.addAudio(`assets/${audioFilename}`);
     const that = this;
     audio.addEventListener("play", () => {
       this.pendingNetwork = false;
       that.playLayer += 1;
-      this.$status.playCount++;
+      console.log("Playlay+", this.playLayer);
     });
-    audio.addEventListener("ended", () => {
+    audio.addEventListener("pause", () => {
       that.playLayer -= 1;
-      this.$status.playCount--;
+      console.log("Playlay-", this.playLayer);
     });
-    audio.play();
   }
 }
 </script>

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -56,14 +56,19 @@ export default class BaseButton extends Vue {
     }
     this.pendingNetwork = true;
     const audio = this.$status.player.addAudio(`assets/${audioFilename}`);
-    const that = this;
     audio.addEventListener("play", () => {
       this.pendingNetwork = false;
-      that.playLayer += 1;
+      this.playLayer += 1;
+      if (this.playLayer === 1) {
+        this.$emit("started");
+      }
       console.log("Playlay+", this.playLayer);
     });
     audio.addEventListener("pause", () => {
-      that.playLayer -= 1;
+      this.playLayer -= 1;
+      if (this.playLayer === 0) {
+        this.$emit("stopped");
+      }
       console.log("Playlay-", this.playLayer);
     });
   }

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -62,14 +62,12 @@ export default class BaseButton extends Vue {
       if (this.playLayer === 1) {
         this.$emit("started");
       }
-      console.log("Playlay+", this.playLayer);
     });
     audio.addEventListener("pause", () => {
       this.playLayer -= 1;
       if (this.playLayer === 0) {
         this.$emit("stopped");
       }
-      console.log("Playlay-", this.playLayer);
     });
   }
 }

--- a/src/components/centralPlayer.ts
+++ b/src/components/centralPlayer.ts
@@ -7,11 +7,9 @@ export default class CentralPlayer {
     this.audios.push(audio);
     audio.addEventListener("play", () => {
       this.playCount += 1;
-      console.log("Playcnt+", this.playCount);
     });
     audio.addEventListener("pause", () => {
       this.playCount -= 1;
-      console.log("Playcnt-", this.playCount);
     });
     if (playNow) {
       audio.addEventListener("loadeddata", () => {

--- a/src/components/centralPlayer.ts
+++ b/src/components/centralPlayer.ts
@@ -1,0 +1,34 @@
+export default class CentralPlayer {
+  private audios: HTMLAudioElement[] = [];
+  public multiPlay = true;
+  public playCount = 0;
+  addAudio(url: string, playNow = true): HTMLAudioElement {
+    const audio = new Audio(url);
+    this.audios.push(audio);
+    audio.addEventListener("play", () => {
+      this.playCount += 1;
+      console.log("Playcnt+", this.playCount);
+    });
+    audio.addEventListener("pause", () => {
+      this.playCount -= 1;
+      console.log("Playcnt-", this.playCount);
+    });
+    if (playNow) {
+      audio.addEventListener("loadeddata", () => {
+        if (!this.multiPlay) {
+          this.stopAll();
+        }
+        audio.play();
+      });
+    }
+    return audio;
+  }
+  preload(url: string) {
+    this.addAudio(url, false);
+  }
+  stopAll() {
+    for (const i of this.audios) {
+      i.pause();
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,14 @@ import Vue from "vue";
 import App from "./App.vue";
 import router from "./router";
 import { i18n } from "./i18n-setup";
+import CentralPlayer from "./components/centralPlayer";
 
 import "./registerServiceWorker";
 
 Vue.prototype.$status = {
-  multiPlay: true,
   darkMode: false,
-  playCount: 0
+  playCount: 0,
+  player: new CentralPlayer()
 };
 
 Vue.config.productionTip = false;

--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -15,6 +15,7 @@
 }
 
 $btn-height: 40px;
+$btn-hover-font-weight: 900;
 
 .normalBtn {
   text-align: center;
@@ -35,12 +36,12 @@ $btn-height: 40px;
   font-weight: 0.23s ease-in-out;
 
   &.testHoverWidth {
-    font-weight: 800;
+    font-weight: $btn-hover-font-weight;
   }
 
   &:hover {
     cursor: pointer;
-    font-weight: 800;
+    font-weight: $btn-hover-font-weight;
     box-shadow: 0 0.4px 0.7px rgba(0, 0, 0, 0.02),
       0 1px 1.6px rgba(0, 0, 0, 0.028), 0 1.9px 3px rgba(0, 0, 0, 0.035),
       0 3.4px 5.4px rgba(102, 116, 181, 0.042),
@@ -51,6 +52,6 @@ $btn-height: 40px;
 
 .playingBtn,
 .animateBtn:hover {
-  font-weight: 900;
+  font-weight: $btn-hover-font-weight;
   transition: box-shadow 0.23s ease-in-out, font-weight 0.23s ease-in-out;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,13 @@
+import CentralPlayer from "./components/centralPlayer";
+
 export interface Sound {
   name: string;
   name_l10n?: { [key: string]: string };
   file: string | string[];
   type: string;
+}
+
+export interface PageStatus {
+  darkMode: boolean;
+  player: CentralPlayer;
 }

--- a/src/views/EditorView.vue
+++ b/src/views/EditorView.vue
@@ -135,7 +135,6 @@ export default class App extends Vue {
         }
       }
     }
-    console.log(this.sounds);
   }
 
   private validateDisplay() {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -27,7 +27,11 @@
             ></BaseButton>
           </template>
         </div>
-        <span id="bigButtonText" :tabindex="displayMusicBoard ? -1 : 0">
+        <span
+          id="bigButtonText"
+          :class="{ playingBtn }"
+          :tabindex="displayMusicBoard ? -1 : 0"
+        >
           {{ ehhhLocalizedName }}
         </span>
       </div>
@@ -36,6 +40,8 @@
       id="virtualCentralButton"
       :item="sounds[0]"
       ref="centralButton"
+      @started="playingBtn = true"
+      @stopped="playingBtn = false"
     ></BaseButton>
     <div
       id="switchBtn"
@@ -98,6 +104,7 @@ export default class App extends Vue {
   private displayMusicBoard = false;
   private settings: string[] = [];
   private darkMode = false;
+  private playingBtn = false;
 
   @Watch("settings")
   private updateSettings(newValue: string[]) {

--- a/src/views/MainView.vue
+++ b/src/views/MainView.vue
@@ -102,7 +102,7 @@ export default class App extends Vue {
   @Watch("settings")
   private updateSettings(newValue: string[]) {
     this.darkMode = this.$status.darkMode = newValue.includes("darkMode");
-    this.$status.multiPlay = newValue.includes("multiPlay");
+    this.$status.player.multiPlay = newValue.includes("multiPlay");
   }
 
   get ehhhLocalizedName() {

--- a/src/vue-extends.d.ts
+++ b/src/vue-extends.d.ts
@@ -1,10 +1,10 @@
-import Vue, { VueConstructor } from 'vue';
+import { PageStatus } from "./types";
 
-declare module 'vue/types/vue' {
-    interface Vue {
-        $status: any;
-    }
-    interface VueConstructor {
-        $status: any;
-    }
+declare module "vue/types/vue" {
+  interface Vue {
+    $status: PageStatus;
+  }
+  interface VueConstructor {
+    $status: PageStatus;
+  }
 }


### PR DESCRIPTION
This PR centralized the sound playing module. Reasons:
1. Better control over sound playing
2. Optimize the loading experience: now the previous sound clip doesn't stop unless the next sound clip selected is fully loaded and ready to play
3. In non-multiplay mode, clicking a button while playing will play the next sound clip as soon as it's finished loading (as [Fubuki Button](https://sfubuki.moe/)). In the previous versions, the page simply ignores button clicks during sound clip playing.

The changes have not gain community consensus.

The changes are based on branch `night-mode` and should merge after that.