### PR TITLE
fix: not play sound on iOS

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -73,22 +73,24 @@ export default class BaseButton extends Vue {
       ];
     }
     this.pendingNetwork = true;
-    let audio;
+    let audio: HTMLAudioElement | null = null;
     try {
       audio = this.$status.player.addAudio(`assets/${audioFilename}`);
-    } catch (_) {
       this.$status.player.stopAllWhenNonMultiPlay();
-      (audio as HTMLAudioElement).play();
+      audio?.play();
+    } catch (err) {
+      this.$status.player.stopAllWhenNonMultiPlay();
+      audio?.play();
     }
 
-    (audio as HTMLAudioElement).addEventListener("play", () => {
+    audio?.addEventListener("play", () => {
       this.pendingNetwork = false;
       this.playLayer += 1;
       if (this.playLayer === 1) {
         this.$emit("started");
       }
     });
-    (audio as HTMLAudioElement).addEventListener("pause", () => {
+    audio?.addEventListener("pause", () => {
       this.playLayer -= 1;
       if (this.playLayer === 0) {
         this.$emit("stopped");

--- a/src/components/centralPlayer.ts
+++ b/src/components/centralPlayer.ts
@@ -1,16 +1,11 @@
 export default class CentralPlayer {
-  // private audios: HTMLAudioElement[] = [];
-  private audios: Map<string, HTMLAudioElement> = new Map;
+  private audios: HTMLAudioElement[] = [];
   public multiPlay = true;
   public playCount = 0;
   addAudio(url: string, playNow = true): HTMLAudioElement {
-    if (this.audios.has(url)) {
-      return this.audios.get(url)!
-    }
-
     const audio = new Audio();
     audio.preload = "auto";
-    this.audios.set(url, audio);
+    this.audios.push(audio);
     audio.addEventListener("play", () => {
       this.playCount += 1;
     });

--- a/src/components/centralPlayer.ts
+++ b/src/components/centralPlayer.ts
@@ -1,22 +1,29 @@
 export default class CentralPlayer {
-  private audios: HTMLAudioElement[] = [];
+  // private audios: HTMLAudioElement[] = [];
+  private audios: Map<string, HTMLAudioElement> = new Map;
   public multiPlay = true;
   public playCount = 0;
   addAudio(url: string, playNow = true): HTMLAudioElement {
-    const audio = new Audio(url);
-    this.audios.push(audio);
+    if (this.audios.has(url)) {
+      return this.audios.get(url)!
+    }
+
+    const audio = new Audio();
+    audio.preload = "auto";
+    this.audios.set(url, audio);
     audio.addEventListener("play", () => {
       this.playCount += 1;
     });
     audio.addEventListener("pause", () => {
       this.playCount -= 1;
     });
-    if (playNow) {
-      audio.addEventListener("loadeddata", () => {
-        this.stopAllWhenNonMultiPlay();
-        audio.play();
-      });
-    }
+    // if (playNow) {
+    //   audio.addEventListener("loadeddata", () => {
+    //     this.stopAllWhenNonMultiPlay();
+    //     audio.play();
+    //   });
+    // }
+    audio.src = url;
     return audio;
   }
 
@@ -30,7 +37,7 @@ export default class CentralPlayer {
     this.addAudio(url, false);
   }
   stopAll() {
-    for (const i of this.audios) {
+    for (const i of this.audios.values()) {
       i.pause();
     }
   }


### PR DESCRIPTION
it did fix 'Unable to play music' in https://github.com/suisei-cn/starbuttons/issues/33 on iOS browsers (also tested on Android 9 Chrome 83)
I think the problem is that audio doesn't get loaded until user hits the play button on iOS
but since the size of sound files are pretty small, just uses play() will be ok, I suppose :)